### PR TITLE
Add typology weight admin

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -55,7 +55,9 @@ def create_app(config_name="development"):
     
     # Регіструємо blueprint'и
     from app.routes import main
+    from app.admin import admin_bp
     app.register_blueprint(main)
+    app.register_blueprint(admin_bp)
     
     # Ініціалізуємо OAuth, окрім тестового оточення. У тестах залежність
     # flask-dance може бути відсутня, тому пропускаємо реєстрацію OAuth

--- a/app/admin.py
+++ b/app/admin.py
@@ -1,0 +1,50 @@
+from flask import Blueprint, render_template, request, redirect, url_for, flash
+from flask_login import login_required
+from .forms import WeightsForm, ComfortScoreForm
+from .statistics_utils import (
+    load_typology_weights,
+    update_typology_weight,
+    update_comfort_score,
+)
+
+admin_bp = Blueprint('admin', __name__, url_prefix='/admin')
+
+
+@admin_bp.route('/', methods=['GET', 'POST'])
+@login_required
+def statistics():
+    weights_form = WeightsForm(prefix='weights')
+    score_form = ComfortScoreForm(prefix='score')
+
+    weights = load_typology_weights()
+    if request.method == 'GET':
+        weights_form.temporistics.data = weights.get('Temporistics', 1.0)
+        weights_form.psychosophia.data = weights.get('Psychosophia', 1.0)
+        weights_form.amatoric.data = weights.get('Amatoric', 1.0)
+        weights_form.socionics.data = weights.get('Socionics', 1.0)
+
+    if weights_form.submit.data and weights_form.validate_on_submit():
+        update_typology_weight('Temporistics', weights_form.temporistics.data)
+        update_typology_weight('Psychosophia', weights_form.psychosophia.data)
+        update_typology_weight('Amatoric', weights_form.amatoric.data)
+        update_typology_weight('Socionics', weights_form.socionics.data)
+        flash('Weights updated', 'success')
+        return redirect(url_for('admin.statistics'))
+
+    if score_form.submit_score.data and score_form.validate_on_submit():
+        try:
+            update_comfort_score(
+                score_form.typology.data,
+                score_form.relationship_type.data,
+                int(score_form.score.data),
+            )
+            flash('Comfort score updated', 'success')
+            return redirect(url_for('admin.statistics'))
+        except ValueError as exc:
+            flash(str(exc), 'danger')
+
+    return render_template(
+        'admin_statistics.html',
+        weights_form=weights_form,
+        score_form=score_form,
+    )

--- a/app/forms.py
+++ b/app/forms.py
@@ -1,7 +1,7 @@
 from flask_wtf import FlaskForm
 from wtforms import (
     StringField, PasswordField, SubmitField, BooleanField, SelectField,
-    FieldList, FormField, HiddenField, FloatField
+    FieldList, FormField, HiddenField, FloatField, IntegerField
 )
 from wtforms.validators import DataRequired, Email, EqualTo, Length, ValidationError
 from app.models import User
@@ -66,3 +66,23 @@ class LanguageForm(FlaskForm):
         ('es', 'Español'),
         ('uk', 'Українська')
     ])
+
+
+class WeightsForm(FlaskForm):
+    temporistics = FloatField(_l("Temporistics"), default=1.0)
+    psychosophia = FloatField(_l("Psychosophia"), default=1.0)
+    amatoric = FloatField(_l("Amatoric"), default=1.0)
+    socionics = FloatField(_l("Socionics"), default=1.0)
+    submit = SubmitField(_l("Save Weights"))
+
+
+class ComfortScoreForm(FlaskForm):
+    typology = SelectField(_l("Typology"), choices=[
+        ('Temporistics', 'Temporistics'),
+        ('Psychosophia', 'Psychosophia'),
+        ('Amatoric', 'Amatoric'),
+        ('Socionics', 'Socionics')
+    ])
+    relationship_type = StringField(_l("Relationship Type"), validators=[DataRequired()])
+    score = IntegerField(_l("Score"), validators=[DataRequired()])
+    submit_score = SubmitField(_l("Save Score"))

--- a/app/statistics_utils.py
+++ b/app/statistics_utils.py
@@ -1,0 +1,80 @@
+import json
+import os
+from typing import Dict
+
+from .services import calculate_relationship
+
+BASE_DIR = os.environ.get(
+    "DATA_DIR",
+    os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "data"),
+)
+WEIGHTS_FILE = os.environ.get("WEIGHTS_FILE", os.path.join(BASE_DIR, "typology_weights.json"))
+
+
+def get_data_path(filename: str) -> str:
+    return os.path.join(BASE_DIR, filename)
+
+
+def load_typology_weights() -> Dict[str, float]:
+    if not os.path.exists(WEIGHTS_FILE):
+        weights = {
+            "Temporistics": 1.0,
+            "Psychosophia": 1.0,
+            "Amatoric": 1.0,
+            "Socionics": 1.0,
+        }
+        with open(WEIGHTS_FILE, "w") as f:
+            json.dump(weights, f, indent=2)
+        return weights
+    with open(WEIGHTS_FILE) as f:
+        return json.load(f)
+
+
+def update_typology_weight(typology_name: str, new_weight: float) -> None:
+    weights = load_typology_weights()
+    weights[typology_name] = new_weight
+    with open(WEIGHTS_FILE, "w") as f:
+        json.dump(weights, f, indent=2)
+
+
+def update_comfort_score(typology_name: str, relationship_type: str, new_score: int) -> None:
+    file_map = {
+        "Temporistics": "temporistics_comfort_scores.json",
+        "Psychosophia": "psychosophia_comfort_scores.json",
+        "Socionics": "socionics_relationships.json",
+        "Amatoric": "amatoric_comfort_scores.json",
+    }
+    filename = file_map.get(typology_name)
+    if not filename:
+        raise ValueError(f"Unknown typology {typology_name}")
+    path = get_data_path(filename)
+    with open(path) as f:
+        data = json.load(f)
+    entry = data.get(relationship_type, {})
+    if isinstance(entry, dict):
+        entry["score"] = new_score
+    else:
+        entry = {"score": new_score, "description": ""}
+    data[relationship_type] = entry
+    with open(path, "w") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def calculate_weighted_compatibility(
+    user1_types: Dict[str, str], user2_types: Dict[str, str], weights: Dict[str, float] | None = None
+) -> float:
+    if weights is None:
+        weights = load_typology_weights()
+    total_weight = 0.0
+    weighted_score = 0.0
+    for typology, weight in weights.items():
+        t1 = user1_types.get(typology)
+        t2 = user2_types.get(typology)
+        if not t1 or not t2:
+            continue
+        _, score = calculate_relationship(t1, t2, typology)
+        weighted_score += score * weight
+        total_weight += weight
+    if total_weight == 0:
+        raise ValueError("No valid typologies for calculation")
+    return weighted_score / total_weight

--- a/app/templates/admin_statistics.html
+++ b/app/templates/admin_statistics.html
@@ -1,0 +1,37 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h2>Statistics Admin</h2>
+<form method="post">
+    {{ weights_form.hidden_tag() }}
+    <h3>Typology Weights</h3>
+    <div>
+        {{ weights_form.temporistics.label }} {{ weights_form.temporistics() }}
+    </div>
+    <div>
+        {{ weights_form.psychosophia.label }} {{ weights_form.psychosophia() }}
+    </div>
+    <div>
+        {{ weights_form.amatoric.label }} {{ weights_form.amatoric() }}
+    </div>
+    <div>
+        {{ weights_form.socionics.label }} {{ weights_form.socionics() }}
+    </div>
+    {{ weights_form.submit() }}
+</form>
+<hr>
+<form method="post">
+    {{ score_form.hidden_tag() }}
+    <h3>Comfort Score</h3>
+    <div>
+        {{ score_form.typology.label }} {{ score_form.typology() }}
+    </div>
+    <div>
+        {{ score_form.relationship_type.label }} {{ score_form.relationship_type() }}
+    </div>
+    <div>
+        {{ score_form.score.label }} {{ score_form.score() }}
+    </div>
+    {{ score_form.submit_score() }}
+</form>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -16,6 +16,7 @@
                 <a class="nav-item nav-link" href="{{ url_for('main.user_profile', username=current_user.username) }}">{{ _('Profile') }}</a>
               <!-- Добавляем новый пункт меню для списка совместимых пользователей поблизости -->
         <a class="nav-item nav-link" href="{{ url_for('main.nearby_compatibles') }}">{{ _('Compatible Nearby') }}</a>
+        <a class="nav-item nav-link" href="{{ url_for('admin.statistics') }}">Admin</a>
       {% else %}
                 <a class="nav-item nav-link" href="{{ url_for('main.register') }}">{{ _('Register') }}</a>
                 <a class="nav-item nav-link" href="{{ url_for('main.login') }}">{{ _('Login') }}</a>

--- a/data/typology_weights.json
+++ b/data/typology_weights.json
@@ -1,0 +1,6 @@
+{
+  "Temporistics": 1.0,
+  "Psychosophia": 1.0,
+  "Amatoric": 1.0,
+  "Socionics": 1.0
+}

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,23 @@
+import json
+from app.extensions import db
+from app.models import User
+from tests.test_helpers import unique_username, unique_email
+
+
+def login_user(client, email, password):
+    client.post('/login', data={'email': email, 'password': password, 'submit': 'Login'}, follow_redirects=True)
+
+
+def test_admin_page_access(client, app, test_db):
+    with app.app_context():
+        username = unique_username('admin')
+        email = unique_email('admin')
+        user = User(username=username, email=email)
+        user.set_password('password')
+        db.session.add(user)
+        db.session.commit()
+
+        login_user(client, email, 'password')
+        response = client.get('/admin/', follow_redirects=True)
+        assert response.status_code == 200
+        assert b'Typology Weights' in response.data

--- a/tests/test_statistics_utils.py
+++ b/tests/test_statistics_utils.py
@@ -1,0 +1,50 @@
+import importlib
+import json
+
+import app.statistics_utils as su
+
+
+def test_load_typology_weights_creates_file(tmp_path, monkeypatch):
+    weights_file = tmp_path / "weights.json"
+    monkeypatch.setenv("WEIGHTS_FILE", str(weights_file))
+    importlib.reload(su)
+    weights = su.load_typology_weights()
+    assert weights["Temporistics"] == 1.0
+    assert weights_file.exists()
+
+
+def test_update_typology_weight(tmp_path, monkeypatch):
+    weights_file = tmp_path / "weights.json"
+    monkeypatch.setenv("WEIGHTS_FILE", str(weights_file))
+    importlib.reload(su)
+    su.load_typology_weights()
+    su.update_typology_weight("Temporistics", 2.0)
+    with open(weights_file) as f:
+        data = json.load(f)
+    assert data["Temporistics"] == 2.0
+
+
+def test_update_comfort_score(tmp_path, monkeypatch):
+    src = su.get_data_path("psychosophia_comfort_scores.json")
+    dest_dir = tmp_path
+    dest = dest_dir / "psychosophia_comfort_scores.json"
+    monkeypatch.setenv("DATA_DIR", str(dest_dir))
+    importlib.reload(su)
+    import shutil
+
+    shutil.copy(src, dest)
+    su.update_comfort_score("Psychosophia", "Identity/Philia", 99)
+    with open(dest) as f:
+        data = json.load(f)
+    assert data["Identity/Philia"]["score"] == 99
+
+
+def test_calculate_weighted_compatibility(tmp_path, monkeypatch):
+    weights_file = tmp_path / "weights.json"
+    monkeypatch.setenv("WEIGHTS_FILE", str(weights_file))
+    importlib.reload(su)
+    su.load_typology_weights()  # create default
+    user1 = {"Temporistics": "Past, Current, Future, Eternity"}
+    user2 = {"Temporistics": "Past, Current, Future, Eternity"}
+    score = su.calculate_weighted_compatibility(user1, user2)
+    assert score == 95


### PR DESCRIPTION
## Summary
- add admin blueprint with weight and score forms
- expose admin page link in navigation
- support new admin forms in application config
- test weight utilities

## Testing
- `pytest tests/test_statistics_utils.py -q`
- `pytest -k "not selenium" -q` *(fails: psycopg connection error)*

------
https://chatgpt.com/codex/tasks/task_e_6842b6b2663c83238311180f8a119f6e