### PR TITLE
Enable typology toggling via admin

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -1,10 +1,12 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash
 from flask_login import login_required
-from .forms import WeightsForm, ComfortScoreForm
+from .forms import WeightsForm, ComfortScoreForm, TypologyStatusForm
 from .statistics_utils import (
     load_typology_weights,
     update_typology_weight,
     update_comfort_score,
+    load_typology_status,
+    update_typology_status,
 )
 
 admin_bp = Blueprint('admin', __name__, url_prefix='/admin')
@@ -15,13 +17,19 @@ admin_bp = Blueprint('admin', __name__, url_prefix='/admin')
 def statistics():
     weights_form = WeightsForm(prefix='weights')
     score_form = ComfortScoreForm(prefix='score')
+    status_form = TypologyStatusForm(prefix='status')
 
     weights = load_typology_weights()
+    status = load_typology_status()
     if request.method == 'GET':
         weights_form.temporistics.data = weights.get('Temporistics', 1.0)
         weights_form.psychosophia.data = weights.get('Psychosophia', 1.0)
         weights_form.amatoric.data = weights.get('Amatoric', 1.0)
         weights_form.socionics.data = weights.get('Socionics', 1.0)
+        status_form.temporistics_enabled.data = status.get('Temporistics', True)
+        status_form.psychosophia_enabled.data = status.get('Psychosophia', True)
+        status_form.amatoric_enabled.data = status.get('Amatoric', True)
+        status_form.socionics_enabled.data = status.get('Socionics', True)
 
     if weights_form.submit.data and weights_form.validate_on_submit():
         update_typology_weight('Temporistics', weights_form.temporistics.data)
@@ -29,6 +37,14 @@ def statistics():
         update_typology_weight('Amatoric', weights_form.amatoric.data)
         update_typology_weight('Socionics', weights_form.socionics.data)
         flash('Weights updated', 'success')
+        return redirect(url_for('admin.statistics'))
+
+    if status_form.submit_status.data and status_form.validate_on_submit():
+        update_typology_status('Temporistics', bool(status_form.temporistics_enabled.data))
+        update_typology_status('Psychosophia', bool(status_form.psychosophia_enabled.data))
+        update_typology_status('Amatoric', bool(status_form.amatoric_enabled.data))
+        update_typology_status('Socionics', bool(status_form.socionics_enabled.data))
+        flash('Status updated', 'success')
         return redirect(url_for('admin.statistics'))
 
     if score_form.submit_score.data and score_form.validate_on_submit():
@@ -47,4 +63,5 @@ def statistics():
         'admin_statistics.html',
         weights_form=weights_form,
         score_form=score_form,
+        status_form=status_form,
     )

--- a/app/forms.py
+++ b/app/forms.py
@@ -76,6 +76,14 @@ class WeightsForm(FlaskForm):
     submit = SubmitField(_l("Save Weights"))
 
 
+class TypologyStatusForm(FlaskForm):
+    temporistics_enabled = BooleanField(_l("Temporistics"), default=True)
+    psychosophia_enabled = BooleanField(_l("Psychosophia"), default=True)
+    amatoric_enabled = BooleanField(_l("Amatoric"), default=True)
+    socionics_enabled = BooleanField(_l("Socionics"), default=True)
+    submit_status = SubmitField(_l("Save Status"))
+
+
 class ComfortScoreForm(FlaskForm):
     typology = SelectField(_l("Typology"), choices=[
         ('Temporistics', 'Temporistics'),

--- a/app/routes.py
+++ b/app/routes.py
@@ -17,6 +17,7 @@ from app.services import get_distance_if_compatible
 from werkzeug.utils import secure_filename
 import os
 from .routes_helper import handle_profile_image_upload, update_user_typology
+from .statistics_utils import load_typology_status
 
 main = Blueprint("main", __name__)
 
@@ -28,8 +29,8 @@ class EmptyForm(FlaskForm):
     csrf_token = HiddenField()
 
 def get_available_typologies():
-    # Возвращает список доступных типологий
-    return ["Temporistics", "Psychosophia", "Amatoric", "Socionics"]
+    status = load_typology_status()
+    return [name for name, enabled in status.items() if enabled]
 
 def is_safe_url(target):
     ref_url = urlparse(request.host_url)

--- a/app/statistics_utils.py
+++ b/app/statistics_utils.py
@@ -9,6 +9,7 @@ BASE_DIR = os.environ.get(
     os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "data"),
 )
 WEIGHTS_FILE = os.environ.get("WEIGHTS_FILE", os.path.join(BASE_DIR, "typology_weights.json"))
+STATUS_FILE = os.environ.get("STATUS_FILE", os.path.join(BASE_DIR, "typology_status.json"))
 
 
 def get_data_path(filename: str) -> str:
@@ -35,6 +36,28 @@ def update_typology_weight(typology_name: str, new_weight: float) -> None:
     weights[typology_name] = new_weight
     with open(WEIGHTS_FILE, "w") as f:
         json.dump(weights, f, indent=2)
+
+
+def load_typology_status() -> Dict[str, bool]:
+    if not os.path.exists(STATUS_FILE):
+        status = {
+            "Temporistics": True,
+            "Psychosophia": True,
+            "Amatoric": True,
+            "Socionics": True,
+        }
+        with open(STATUS_FILE, "w") as f:
+            json.dump(status, f, indent=2)
+        return status
+    with open(STATUS_FILE) as f:
+        return json.load(f)
+
+
+def update_typology_status(typology_name: str, enabled: bool) -> None:
+    status = load_typology_status()
+    status[typology_name] = enabled
+    with open(STATUS_FILE, "w") as f:
+        json.dump(status, f, indent=2)
 
 
 def update_comfort_score(typology_name: str, relationship_type: str, new_score: int) -> None:

--- a/app/templates/admin_statistics.html
+++ b/app/templates/admin_statistics.html
@@ -21,6 +21,24 @@
 </form>
 <hr>
 <form method="post">
+    {{ status_form.hidden_tag() }}
+    <h3>Enable Typologies</h3>
+    <div>
+        {{ status_form.temporistics_enabled.label }} {{ status_form.temporistics_enabled() }}
+    </div>
+    <div>
+        {{ status_form.psychosophia_enabled.label }} {{ status_form.psychosophia_enabled() }}
+    </div>
+    <div>
+        {{ status_form.amatoric_enabled.label }} {{ status_form.amatoric_enabled() }}
+    </div>
+    <div>
+        {{ status_form.socionics_enabled.label }} {{ status_form.socionics_enabled() }}
+    </div>
+    {{ status_form.submit_status() }}
+</form>
+<hr>
+<form method="post">
     {{ score_form.hidden_tag() }}
     <h3>Comfort Score</h3>
     <div>

--- a/data/typology_status.json
+++ b/data/typology_status.json
@@ -1,0 +1,6 @@
+{
+  "Temporistics": true,
+  "Psychosophia": true,
+  "Amatoric": true,
+  "Socionics": true
+}

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -21,3 +21,5 @@ def test_admin_page_access(client, app, test_db):
         response = client.get('/admin/', follow_redirects=True)
         assert response.status_code == 200
         assert b'Typology Weights' in response.data
+        assert b'Enable Typologies' in response.data
+

--- a/tests/test_statistics_utils.py
+++ b/tests/test_statistics_utils.py
@@ -48,3 +48,23 @@ def test_calculate_weighted_compatibility(tmp_path, monkeypatch):
     user2 = {"Temporistics": "Past, Current, Future, Eternity"}
     score = su.calculate_weighted_compatibility(user1, user2)
     assert score == 95
+
+
+def test_load_typology_status_creates_file(tmp_path, monkeypatch):
+    status_file = tmp_path / "status.json"
+    monkeypatch.setenv("STATUS_FILE", str(status_file))
+    importlib.reload(su)
+    status = su.load_typology_status()
+    assert status["Temporistics"] is True
+    assert status_file.exists()
+
+
+def test_update_typology_status(tmp_path, monkeypatch):
+    status_file = tmp_path / "status.json"
+    monkeypatch.setenv("STATUS_FILE", str(status_file))
+    importlib.reload(su)
+    su.load_typology_status()
+    su.update_typology_status("Temporistics", False)
+    with open(status_file) as f:
+        data = json.load(f)
+    assert data["Temporistics"] is False


### PR DESCRIPTION
## Summary
- add checkbox form for enabling typologies
- support new typology status in admin blueprint
- load typology status for routes
- store status in `typology_status.json`
- add tests for typology status functions

## Testing
- `pytest tests/test_statistics_utils.py::test_load_typology_status_creates_file -q`
- `pytest -q` *(fails: ModuleNotFoundError / SystemError: initialization of _psycopg raised unreported exception)*

------
https://chatgpt.com/codex/tasks/task_e_6842baccf45883238f5d2c3ebbfa68a7