### PR TITLE
Add psycopg2 dependency for tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.8-slim AS builder
 WORKDIR /app
 COPY requirements.txt .
-RUN apt-get update && apt-get install -y gcc libc6-dev
+RUN apt-get update && apt-get install -y gcc libc6-dev libpq-dev
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Copy the dependencies and application code

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,11 @@ python-dotenv==1.0.1
 Flask-Login==0.6.3
 email-validator==1.1.1
 psycopg2-binary==2.9
+psycopg2==2.9
 Flask-Babel>=2.0.0
 passlib[bcrypt]
 pytest==7.1.3
 selenium==4.18.1
 webdriver-manager==4.0.1
+Pillow==10.2.0
 


### PR DESCRIPTION
## Summary
- include `psycopg2` and `Pillow` in `requirements.txt`
- ensure docker image installs libpq-dev for psycopg2

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=$(pwd) pytest -k "not selenium" -q` *(fails: initialization of _psycopg raised unreported exception)*

------
https://chatgpt.com/codex/tasks/task_e_6842be902af88323a5b0073565791e72