### PR TITLE
Add UX/UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ This application is built with **Flask** and lets users choose psychological "ty
 - **Templates & Static Assets** under `app/templates/` provide the interface; translations live in `translations/` and `locales/`.
 - **Tests** in `tests/` cover algorithms, routes, models, localization, and Selenium end-to-end cases with about 93% coverage.
 
+### UX/UI Improvements
+
+Recent updates introduce accessibility and responsive design best practices:
+
+- Added `<meta charset>` and viewport tags for mobile-friendly rendering.
+- Navigation now uses semantic roles and supports keyboard skipping with a "Skip to main content" link.
+- Flash messages announce updates with `role="alert"` for screen readers.
+- Inputs feature placeholder text, and styles adapt to smaller screens.
+
 ### Getting Started
 
 1. Install dependencies: `pip install -r requirements.txt`.

--- a/app/forms.py
+++ b/app/forms.py
@@ -15,10 +15,26 @@ class TypologyTypeForm(FlaskForm):
     type_value = SelectField(_l("Type Value"), validators=[DataRequired()], choices=[])
 
 class RegistrationForm(FlaskForm):
-    username = StringField(_l("Username"), validators=[DataRequired(), Length(min=2, max=20)])
-    email = StringField(_l("Email"), validators=[DataRequired(), Email()])
-    password = PasswordField(_l("Password"), validators=[DataRequired()])
-    confirm_password = PasswordField(_l("Confirm Password"), validators=[DataRequired(), EqualTo("password")])
+    username = StringField(
+        _l("Username"),
+        validators=[DataRequired(), Length(min=2, max=20)],
+        render_kw={"placeholder": _l("Username")}
+    )
+    email = StringField(
+        _l("Email"),
+        validators=[DataRequired(), Email()],
+        render_kw={"placeholder": _l("Email")}
+    )
+    password = PasswordField(
+        _l("Password"),
+        validators=[DataRequired()],
+        render_kw={"placeholder": _l("Password")}
+    )
+    confirm_password = PasswordField(
+        _l("Confirm Password"),
+        validators=[DataRequired(), EqualTo("password")],
+        render_kw={"placeholder": _l("Confirm Password")}
+    )
     typologies = FieldList(FormField(TypologyTypeForm))
     profile_image = FileField(_l("Profile Image"), validators=[FileAllowed(['jpg', 'png', 'jpeg'], _l('Images only!'))])
     submit = SubmitField(_l("Sign Up"))
@@ -34,8 +50,16 @@ class RegistrationForm(FlaskForm):
             raise ValidationError(_l("That email is already registered. Please choose a different one."))
 
 class LoginForm(FlaskForm):
-    email = StringField(_l("Email"), validators=[DataRequired(), Email()])
-    password = PasswordField(_l("Password"), validators=[DataRequired()])
+    email = StringField(
+        _l("Email"),
+        validators=[DataRequired(), Email()],
+        render_kw={"placeholder": _l("Email")}
+    )
+    password = PasswordField(
+        _l("Password"),
+        validators=[DataRequired()],
+        render_kw={"placeholder": _l("Password")}
+    )
     remember = BooleanField(_l("Remember Me"))
     submit = SubmitField(_l("Login"))
 

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -3,19 +3,32 @@ body {
   background-color: #f8f9fa;
 }
 
+
 .navbar-nav {
   background-color: #343a40;
   padding: 10px;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 .navbar-nav a {
   color: #ffffff;
   margin-right: 10px;
   text-decoration: none;
+  padding: 5px 10px;
+}
+
+.navbar-nav a:focus,
+.navbar-nav a:hover {
+  text-decoration: underline;
 }
 
 .container {
   margin-top: 20px;
+  max-width: 900px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 0 15px;
 }
 
 .form-group {
@@ -62,4 +75,35 @@ body {
 
 .language-switcher select {
   padding: 5px;
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 10px;
+  padding: 8px;
+  background: #343a40;
+  color: #ffffff;
+  text-decoration: none;
+  z-index: 1000;
+}
+
+@media (max-width: 600px) {
+  .navbar-nav {
+    flex-direction: column;
+  }
+  .navbar-nav a {
+    margin-right: 0;
+    margin-bottom: 5px;
+  }
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,14 +1,18 @@
 <!DOCTYPE html>
 <html lang="{{ current_locale }}">
 <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{{ _('Psychological Calculator') }}{% endblock %}</title>
+    <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}" type="image/x-icon">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <!-- Font Awesome для іконок -->
+    <!-- Font Awesome для иконок -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
-    <nav>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <nav role="navigation" aria-label="Main navigation">
         <div class="navbar-nav">
             <a class="nav-item nav-link" href="{{ url_for('main.index') }}">{{ _('Home') }}</a>
             {% if current_user.is_authenticated %}
@@ -28,7 +32,7 @@
     {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
             {% for category, message in messages %}
-                <div class="alert alert-{{ category }}">{{ message }}</div>
+                <div class="alert alert-{{ category }}" role="alert" aria-live="assertive">{{ message }}</div>
             {% endfor %}
         {% endif %}
     {% endwith %}
@@ -47,7 +51,7 @@
         </div>
     {% endif %}
 
-    <div class="container">
+    <div id="main-content" class="container">
         {% block content %}{% endblock %}
     </div>
 


### PR DESCRIPTION
## Summary
- add meta viewport, favicon, navigation roles, and skip link
- make container accessible to screen readers
- style navbar using flexbox with responsive adjustments
- add skip-link styles and responsive container
- add placeholders in forms for better UX
- document UX/UI updates in README

## Testing
- `pip install -q -r requirements.txt`
- `export PYTHONPATH="$PYTHONPATH:$(pwd)"`
- `export USE_TEST_DB_URL="sqlite:///test.db"`
- `export FLASK_CONFIG=testing`
- `export TEST_DB_URL="sqlite:///:memory:"`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ff0c97d083238c8639d15f8292eb