### PR TITLE
Add Temporistics questionnaire module

### DIFF
--- a/app/temporistics_test.py
+++ b/app/temporistics_test.py
@@ -1,0 +1,76 @@
+from typing import List, Dict
+from collections import Counter
+
+# Simple questionnaire used to infer a Temporistics type.
+# Each question offers four options, each corresponding to a time aspect.
+# The answer key associates option letters with aspects.
+TEMPORISTICS_QUESTIONS: List[Dict[str, Dict[str, str]]] = [
+    {
+        "question": "When planning important decisions you are guided mostly by:",
+        "options": {
+            "A": {"aspect": "Past", "text": "Past experience"},
+            "B": {"aspect": "Current", "text": "Present circumstances"},
+            "C": {"aspect": "Future", "text": "Future possibilities"},
+            "D": {"aspect": "Eternity", "text": "Timeless principles"},
+        },
+    },
+    {
+        "question": "Which perspective best matches your everyday thinking?",
+        "options": {
+            "A": {"aspect": "Past", "text": "Recollections"},
+            "B": {"aspect": "Current", "text": "Here and now"},
+            "C": {"aspect": "Future", "text": "Plans"},
+            "D": {"aspect": "Eternity", "text": "Philosophical ideas"},
+        },
+    },
+    {
+        "question": "What motivates you most?",
+        "options": {
+            "A": {"aspect": "Past", "text": "Traditions"},
+            "B": {"aspect": "Current", "text": "Immediate needs"},
+            "C": {"aspect": "Future", "text": "Long‑term goals"},
+            "D": {"aspect": "Eternity", "text": "Eternal values"},
+        },
+    },
+    {
+        "question": "Choose the statement that resonates with you:",
+        "options": {
+            "A": {"aspect": "Past", "text": "History repeats"},
+            "B": {"aspect": "Current", "text": "Live for today"},
+            "C": {"aspect": "Future", "text": "The best is ahead"},
+            "D": {"aspect": "Eternity", "text": "Timeless truth"},
+        },
+    },
+]
+
+ASPECT_ORDER = ["Past", "Current", "Future", "Eternity"]
+
+def calculate_temporistics_type(answers: List[str]) -> str:
+    """Return a temporistics type from provided answers.
+
+    Parameters
+    ----------
+    answers: List[str]
+        List of option letters corresponding to ``TEMPORISTICS_QUESTIONS``.
+
+    Returns
+    -------
+    str
+        Comma-separated string of aspects ordered from most to least frequent.
+    """
+    if len(answers) != len(TEMPORISTICS_QUESTIONS):
+        raise ValueError("Number of answers does not match questions")
+
+    counts = Counter()
+    for answer, question in zip(answers, TEMPORISTICS_QUESTIONS):
+        option = question["options"].get(answer.upper())
+        if not option:
+            raise ValueError(f"Invalid answer: {answer}")
+        counts[option["aspect"]] += 1
+
+    # Sort aspects by frequency, falling back to predefined ASPECT_ORDER
+    sorted_aspects = sorted(
+        ASPECT_ORDER,
+        key=lambda a: (-counts[a], ASPECT_ORDER.index(a))
+    )
+    return ", ".join(sorted_aspects)

--- a/tests/test_temporistics_test.py
+++ b/tests/test_temporistics_test.py
@@ -1,0 +1,16 @@
+import pytest
+from app.temporistics_test import calculate_temporistics_type
+
+
+def test_calculate_temporistics_type_default_order():
+    """Each aspect chosen once should yield the predefined order."""
+    answers = ["A", "B", "C", "D"]
+    result = calculate_temporistics_type(answers)
+    assert result == "Past, Current, Future, Eternity"
+
+
+def test_calculate_temporistics_type_future_priority():
+    """More 'Future' answers should place Future first."""
+    answers = ["C", "C", "B", "A"]
+    result = calculate_temporistics_type(answers)
+    assert result.startswith("Future")

--- a/tests/test_typologies.py
+++ b/tests/test_typologies.py
@@ -25,6 +25,14 @@ def test_typology_temporistics_invalid_quadra(typology):
     with pytest.raises(ValueError):
         typology.get_quadra_types("NonExistentQuadra")
 
+def test_typology_temporistics_all_types():
+    """Typology should generate all 24 unique time aspect combinations."""
+    typology = TypologyTemporistics()
+    all_types = typology.get_all_types()
+    assert len(all_types) == 24
+    assert len(set(all_types)) == 24
+    assert "Past, Current, Future, Eternity" in all_types
+
 def test_typology_temporistics_relationships(typology):
     all_types = typology.get_all_types()
     assert len(all_types) > 0
@@ -172,3 +180,15 @@ def test_temporistics_detailed_relationships():
     assert relationship in ["Heterotemporality", "Neutrality", "Therapy-Misunderstanding"]
     score, desc = temporistics.get_comfort_score(relationship)
     assert score > 40
+
+def test_typology_temporistics_quadra_description():
+    """Ensure quadra descriptions are returned for valid names."""
+    typology = TypologyTemporistics()
+    description = typology.get_quadra_description("Antipodes")
+    assert "one-plane" in description
+
+
+def test_temporistics_get_time_periods_short():
+    """Check that temporal aspects are shortened to initials."""
+    short = TypologyTemporistics.get_time_periods_short(["Past", "Current", "Future", "Eternity"])
+    assert short == ["P", "C", "F", "E"]


### PR DESCRIPTION
## Summary
- implement a small questionnaire for inferring a Temporistics type
- test questionnaire logic

## Testing
- `pytest tests/test_temporistics_test.py -q`
- `pytest -q` *(fails: SystemError: initialization of _psycopg raised unreported exception)*

------
https://chatgpt.com/codex/tasks/task_e_68502e38ff708323b0ce488153049a00