### PR TITLE
Add profession field with privacy option

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -39,6 +39,8 @@ class RegistrationForm(FlaskForm):
     profile_image = FileField(_l("Profile Image"), validators=[FileAllowed(['jpg', 'png', 'jpeg'], _l('Images only!'))])
     city = StringField(_l("City"))
     country = StringField(_l("Country"))
+    profession = StringField(_l("Profession"))
+    show_profession = BooleanField(_l("Show Profession"), default=True)
     submit = SubmitField(_l("Sign Up"))
 
     def validate_username(self, username):
@@ -74,6 +76,8 @@ class EditProfileForm(FlaskForm):
     longitude = FloatField(_l("Longitude"), validators=[DataRequired()])
     city = StringField(_l("City"))
     country = StringField(_l("Country"))
+    profession = StringField(_l("Profession"))
+    show_profession = BooleanField(_l("Show Profession"), default=True)
     max_distance = FloatField(_l("Maximum Acceptable Distance (km)"), validators=[])
     profile_image = FileField(_l("Profile Image"), validators=[FileAllowed(['jpg', 'png', 'jpeg'], _l('Images only!'))])
     submit = SubmitField(_l("Save Changes"))
@@ -86,6 +90,8 @@ class ProfileForm(FlaskForm):
     longitude = FloatField(_l("Longitude"), validators=[])
     city = StringField(_l("City"))
     country = StringField(_l("Country"))
+    profession = StringField(_l("Profession"))
+    show_profession = BooleanField(_l("Show Profession"), default=True)
     max_distance = FloatField(_l("Maximum Acceptable Distance (km)"), validators=[])
     submit = SubmitField(_l("Save Changes"))
 

--- a/app/models.py
+++ b/app/models.py
@@ -2,7 +2,7 @@ from .extensions import db
 from flask_login import UserMixin
 from passlib.hash import bcrypt
 from sqlalchemy.orm import relationship
-from sqlalchemy import Column, Integer, String, ForeignKey, Float
+from sqlalchemy import Column, Integer, String, ForeignKey, Float, Boolean
 from sqlalchemy import event
 from app.services import get_typology_instance
 
@@ -23,6 +23,10 @@ class User(UserMixin, db.Model):
     longitude = Column(Float, nullable=True)
     city = Column(String(100), nullable=True)
     country = Column(String(100), nullable=True)
+
+    # Profession info
+    profession = Column(String(120), nullable=True)
+    profession_visible = Column(Boolean, default=True)
     
     # Додаємо поле для зберігання максимальної прийнятної відстані (в км)
     max_distance = Column(Float, nullable=True, default=50.0)

--- a/app/routes.py
+++ b/app/routes.py
@@ -155,8 +155,14 @@ def register():
 
     if request.method == "POST":
         if form.validate_on_submit():
-            user = User(username=form.username.data, email=form.email.data,
-                        city=form.city.data, country=form.country.data)
+            user = User(
+                username=form.username.data,
+                email=form.email.data,
+                city=form.city.data,
+                country=form.country.data,
+                profession=form.profession.data,
+                profession_visible=form.show_profession.data,
+            )
             user.set_password(form.password.data)
             db.session.add(user)
 
@@ -244,6 +250,10 @@ def user_profile(username):
         if user.user_type:
             form.typology_name.data = user.user_type.typology_name
             form.type_value.data = user.user_type.type_value
+        form.city.data = user.city
+        form.country.data = user.country
+        form.profession.data = user.profession
+        form.show_profession.data = user.profession_visible
 
     if form.validate_on_submit():
         # Логування даних для діагностики
@@ -253,6 +263,10 @@ def user_profile(username):
         
         # Оновлення email
         user.email = form.email.data
+        user.city = form.city.data
+        user.country = form.country.data
+        user.profession = form.profession.data
+        user.profession_visible = form.show_profession.data
         current_app.logger.info(f"Email after update: {user.email}")
         
         # Оновлення типології
@@ -296,6 +310,8 @@ def edit_profile():
             longitude=form.longitude.data,
             city=form.city.data,
             country=form.country.data,
+            profession=form.profession.data,
+            profession_visible=form.show_profession.data,
             max_distance=form.max_distance.data,
         )
 

--- a/app/services.py
+++ b/app/services.py
@@ -47,7 +47,8 @@ def calculate_relationship(user1, user2, typology):
     comfort_score, _ = typology_instance.get_comfort_score(relationship_type)
     return relationship_type, comfort_score
 
-def update_user_profile(user, username, email, typology_name, type_value, latitude, longitude, city=None, country=None, max_distance=None):
+def update_user_profile(user, username, email, typology_name, type_value, latitude, longitude,
+                        city=None, country=None, profession=None, profession_visible=None, max_distance=None):
     user.username = username
     user.email = email
     if user.user_type:
@@ -69,6 +70,10 @@ def update_user_profile(user, username, email, typology_name, type_value, latitu
         user.city = city
     if country is not None:
         user.country = country
+    if profession is not None:
+        user.profession = profession
+    if profession_visible is not None:
+        user.profession_visible = profession_visible
     
     # Оновлюємо максимальну прийнятну відстань, якщо вона вказана
     if max_distance is not None:

--- a/app/templates/edit_profile.html
+++ b/app/templates/edit_profile.html
@@ -62,6 +62,16 @@
       <label for="country">Country</label>
       {{ form.country(class="form-control") }}
     </div>
+
+    <div>
+      <label for="profession">Profession</label>
+      {{ form.profession(class="form-control") }}
+    </div>
+
+    <div class="form-check">
+      {{ form.show_profession(class="form-check-input") }}
+      {{ form.show_profession.label(class="form-check-label") }}
+    </div>
     
     <div>
       <label for="max_distance">Maximum Acceptable Distance (km)</label>

--- a/app/templates/nearby_compatibles.html
+++ b/app/templates/nearby_compatibles.html
@@ -6,7 +6,11 @@
   <ul>
     {% for user, dist in compatible_list %}
       <li class="user-card">
-        <strong>{{ user.username }}</strong> ({{ user.email }}): {{ dist|round(2) }} km away
+        <strong>{{ user.username }}</strong>
+        {% if user.profession and user.profession_visible %}
+          - {{ user.profession }}
+        {% endif %}
+        ({{ user.email }}): {{ dist|round(2) }} km away
       </li>
     {% endfor %}
   </ul>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -41,6 +41,16 @@
     </div>
 
     <div>
+      <label for="profession">{{ _('Profession') }}</label>
+      {{ form.profession(class="form-control") }}
+    </div>
+
+    <div class="form-check">
+      {{ form.show_profession(class="form-check-input") }}
+      {{ form.show_profession.label(class="form-check-label") }}
+    </div>
+
+    <div>
       {{ form.submit(class="btn btn-primary") }}
     </div>
   </form>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -51,6 +51,14 @@
         {{ form.country(class="form-control form-control-lg") }}
       </div>
       <div class="form-group">
+        {{ form.profession.label(class="form-control-label") }}
+        {{ form.profession(class="form-control form-control-lg") }}
+      </div>
+      <div class="form-group form-check">
+        {{ form.show_profession(class="form-check-input") }}
+        {{ form.show_profession.label(class="form-check-label") }}
+      </div>
+      <div class="form-group">
         {{ form.profile_image.label(class="form-control-label") }}
         {{ form.profile_image(class="form-control form-control-lg") }}
       </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import string
 from datetime import datetime
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
-from sqlalchemy import MetaData, Table, Column, Integer, String, ForeignKey, Float
+from sqlalchemy import MetaData, Table, Column, Integer, String, ForeignKey, Float, Boolean
 from sqlalchemy.ext.declarative import declarative_base
 
 from app import create_app
@@ -60,6 +60,8 @@ def app(db_url):
         Column('longitude', Float),
         Column('city', String(100)),
         Column('country', String(100)),
+        Column('profession', String(120)),
+        Column('profession_visible', Boolean, default=True),
         Column('max_distance', Float, default=50.0),
         Column('google_id', String(256), nullable=True),
         Column('github_id', String(256), nullable=True),

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -208,6 +208,8 @@ def test_register_post_valid(client, app, test_db):
             "email": email,
             "password": "newpassword",
             "confirm_password": "newpassword",
+            "profession": "Engineer",
+            "show_profession": "y",
             "typologies-0-typology_name": "Temporistics",
             "typologies-0-type_value": "Past, Current, Future, Eternity",
             "typologies-1-typology_name": "Psychosophia",
@@ -227,6 +229,8 @@ def test_register_post_valid(client, app, test_db):
 
         new_user = User.query.filter_by(username=username).first()
         assert new_user is not None
+        assert new_user.profession == "Engineer"
+        assert new_user.profession_visible is True
 
 def test_register_post_invalid(client, app, test_db):
     with app.app_context():
@@ -823,3 +827,33 @@ def test_filter_nearby_by_max_distance(client, app, test_db):
         # Тепер обидва користувачі повинні бути на сторінці
         assert username2.encode('utf-8') in response.data
         assert username3.encode('utf-8') in response.data
+
+
+def test_profession_visibility_in_nearby(client, app, test_db):
+    """Users can hide their profession from others"""
+    with app.app_context():
+        # user1 will see user2 in nearby list
+        username1 = unique_username("viewer")
+        email1 = unique_email("viewer")
+        user1 = User(username=username1, email=email1, latitude=50.45, longitude=30.52)
+        user1.set_password("pass1")
+        user1_type = UserType(typology_name="Temporistics", type_value="Past, Current, Future, Eternity")
+        user1.user_type = user1_type
+
+        username2 = unique_username("hidden")
+        email2 = unique_email("hidden")
+        user2 = User(username=username2, email=email2, latitude=50.452, longitude=30.53,
+                     profession="Doctor", profession_visible=False)
+        user2.set_password("pass2")
+        user2_type = UserType(typology_name="Temporistics", type_value="Past, Current, Future, Eternity")
+        user2.user_type = user2_type
+
+        db.session.add_all([user1, user1_type, user2, user2_type])
+        db.session.commit()
+
+        client.post("/login", data={"email": email1, "password": "pass1"}, follow_redirects=True)
+
+        response = client.get("/nearby_compatibles", follow_redirects=True)
+        assert response.status_code == 200
+        assert username2.encode() in response.data
+        assert b"Doctor" not in response.data


### PR DESCRIPTION
## Summary
- allow optional profession with visibility preference
- expose profession fields in registration and profile forms
- show profession on nearby list only if not hidden
- handle profession saving in user model and services
- test profession registration and visibility

## Testing
- `pip install -q -r requirements.txt`
- `export TEST_DB=sqlite`
- `export TEST_DB_URL="sqlite:///:memory:"`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850356309148323bb897e625368386c