### PR TITLE
Use dynaconf for settings

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,12 +5,10 @@ from flask import Flask, request, g, url_for
 from datetime import datetime
 from config import config_dict
 from flask_babel import Babel, _
-from dotenv import load_dotenv
 from flask_caching import Cache
 from flask_wtf.csrf import CSRFProtect
 
-# Загрузимо змінні оточення з .env файлу
-load_dotenv()
+# Змінні оточення вже завантажує Dynaconf у config.py
 cache = Cache()
 babel = Babel()
 csrf = CSRFProtect()
@@ -26,13 +24,7 @@ def create_app(config_name="development"):
     # Застосовуємо конфігурацію
     app.config.from_object(config_dict[config_name])
     
-    # Налаштування OAuth для локальної розробки
-    if config_name == "development":
-        app.config["GOOGLE_CLIENT_ID"] = os.environ.get("GOOGLE_CLIENT_ID")
-        app.config["GOOGLE_CLIENT_SECRET"] = os.environ.get("GOOGLE_CLIENT_SECRET")
-        app.config["GITHUB_CLIENT_ID"] = os.environ.get("GITHUB_CLIENT_ID")
-        app.config["GITHUB_CLIENT_SECRET"] = os.environ.get("GITHUB_CLIENT_SECRET")
-        app.config["OAUTHLIB_INSECURE_TRANSPORT"] = "1"  # Дозволяє використовувати OAuth без HTTPS
+    # OAuth налаштування завантажуються через конфігураційні класи
     
     # Мультимовність
     app.logger.info(f"BABEL_TRANSLATION_DIRECTORIES: {app.config.get('BABEL_TRANSLATION_DIRECTORIES', 'translations')}")

--- a/config.py
+++ b/config.py
@@ -1,34 +1,43 @@
 # config.py
 import os
-from dotenv import load_dotenv
+from dynaconf import Dynaconf
 
-# Загрузим переменные окружения из файла .env, который лежит в корне проекта
-load_dotenv()
+# Dynaconf автоматично завантажує .env та змінні оточення
+settings = Dynaconf(envvar_prefix=False, load_dotenv=True)
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 
 class Config:
-    SECRET_KEY = os.environ.get("SECRET_KEY", "you-will-never-guess")
+    SECRET_KEY = settings.get("SECRET_KEY", "you-will-never-guess")
     # Підтримка як звичайного URL, так і Docker URL (для контейнерів)
-    SQLALCHEMY_DATABASE_URI = os.environ.get("DOCKER_DATABASE_URL", os.environ.get("DATABASE_URL", "postgresql://testuser:password@localhost:5432/testdb"))
+    SQLALCHEMY_DATABASE_URI = settings.get("DOCKER_DATABASE_URL", settings.get("DATABASE_URL", "postgresql://testuser:password@localhost:5432/testdb"))
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     CACHE_TYPE = "simple"
     CACHE_DEFAULT_TIMEOUT = 300
-    BABEL_DEFAULT_LOCALE = os.environ.get("BABEL_DEFAULT_LOCALE", "en")
-    BABEL_DEFAULT_TIMEZONE = os.environ.get("BABEL_DEFAULT_TIMEZONE", "UTC")
-    LANGUAGES = os.environ.get("LANGUAGES", "en,fr,es,uk").split(",")
+    BABEL_DEFAULT_LOCALE = settings.get("BABEL_DEFAULT_LOCALE", "en")
+    BABEL_DEFAULT_TIMEZONE = settings.get("BABEL_DEFAULT_TIMEZONE", "UTC")
+    LANGUAGES = settings.get("LANGUAGES", "en,fr,es,uk").split(",")
     UPLOAD_FOLDER = os.path.join(basedir, 'app', 'static', 'uploads')
 
 class DevelopmentConfig(Config):
     DEBUG = True
+    GOOGLE_CLIENT_ID = settings.get("GOOGLE_CLIENT_ID")
+    GOOGLE_CLIENT_SECRET = settings.get("GOOGLE_CLIENT_SECRET")
+    GITHUB_CLIENT_ID = settings.get("GITHUB_CLIENT_ID")
+    GITHUB_CLIENT_SECRET = settings.get("GITHUB_CLIENT_SECRET")
+    OAUTHLIB_INSECURE_TRANSPORT = "1"
 
 class TestingConfig(Config):
     TESTING = True
     # Використовуємо PostgreSQL для тестів
     # Спочатку перевіряємо USE_TEST_DB_URL, потім DATABASE_URL, інакше використовуємо localhost
-    SQLALCHEMY_DATABASE_URI = os.environ.get("USE_TEST_DB_URL", 
-                            os.environ.get("DATABASE_URL", 
-                            "postgresql://testuser:password@localhost:5432/testdb"))
+    SQLALCHEMY_DATABASE_URI = settings.get(
+        "USE_TEST_DB_URL",
+        settings.get(
+            "DATABASE_URL",
+            "postgresql://testuser:password@localhost:5432/testdb",
+        ),
+    )
     WTF_CSRF_ENABLED = False
     SECRET_KEY = "testsecretkey"
     # Використовуємо окрему папку для тестових завантажень

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ webdriver-manager==4.0.1
 Pillow==10.2.0
 
 openai==1.3.2
+dynaconf==3.2.11


### PR DESCRIPTION
## Summary
- refactor configuration to use dynaconf
- remove direct `os.environ` usage from `create_app`
- add dynaconf dependency

## Testing
- `pip install -r requirements.txt`
- `python -m pytest` *(fails: SystemError initialization errors)*

------
https://chatgpt.com/codex/tasks/task_e_68503a9f055c8323a4487d8585899e7a