### PR TITLE
Centralize user type management

### DIFF
--- a/app/oauth.py
+++ b/app/oauth.py
@@ -6,7 +6,8 @@ from flask_dance.consumer import oauth_authorized, oauth_error
 from flask_login import current_user, login_user
 from sqlalchemy.orm.exc import NoResultFound
 from .extensions import db
-from .models import User, UserType
+from .models import User
+from .services import create_user_type
 
 # Створюємо SQLAlchemy моделі для зберігання OAuth токенів
 class OAuth:
@@ -89,12 +90,11 @@ class OAuth:
                         user.avatar_url = google_info["picture"]
                     
                     # Створюємо базовий тип користувача
-                    user_type = UserType(
+                    user_type = create_user_type(
                         typology_name="Temporistics",
-                        type_value="Past, Current, Future, Eternity"
+                        type_value="Past, Current, Future, Eternity",
+                        commit=False
                     )
-                    db.session.add(user_type)
-                    db.session.flush()
                     user.type_id = user_type.id
                     
                     db.session.add(user)
@@ -167,12 +167,11 @@ class OAuth:
                         user.avatar_url = github_info["avatar_url"]
                     
                     # Створюємо базовий тип користувача
-                    user_type = UserType(
+                    user_type = create_user_type(
                         typology_name="Temporistics",
-                        type_value="Past, Current, Future, Eternity"
+                        type_value="Past, Current, Future, Eternity",
+                        commit=False
                     )
-                    db.session.add(user_type)
-                    db.session.flush()
                     user.type_id = user_type.id
                     
                     db.session.add(user)

--- a/app/routes_helper.py
+++ b/app/routes_helper.py
@@ -2,8 +2,7 @@
 import os
 from flask import current_app, flash
 from werkzeug.utils import secure_filename
-from app.extensions import db
-from app.models import UserType
+from app.services import assign_user_type
 
 def handle_profile_image_upload(file, user):
     if not file:
@@ -30,12 +29,5 @@ def handle_profile_image_upload(file, user):
     return True
 
 def update_user_typology(user, typology_name, type_value):
-    if user.user_type:
-        user.user_type.typology_name = typology_name
-        user.user_type.type_value = type_value
-    else:
-        user_type = UserType(typology_name=typology_name, type_value=type_value)
-        db.session.add(user_type)
-        db.session.commit()
-        user.type_id = user_type.id
-    db.session.commit()
+    """Backward-compatible wrapper around :func:`assign_user_type`."""
+    assign_user_type(user, typology_name, type_value)


### PR DESCRIPTION
## Summary
- centralize creation/update of `UserType`
- reuse new helpers in registration, profile editing and OAuth

## Testing
- `pytest -q` *(fails: initialization of _psycopg raised unreported exception)*

------
https://chatgpt.com/codex/tasks/task_e_68503a833940832385ce3790197661cf