### PR TITLE
Refactor service layer

### DIFF
--- a/app/domain_services.py
+++ b/app/domain_services.py
@@ -1,0 +1,106 @@
+import math
+from flask import current_app
+from .extensions import cache
+from .typologies import (
+    TypologyTemporistics,
+    TypologyPsychosophia,
+    TypologyAmatoric,
+    TypologySocionics,
+)
+
+
+# Central registry for available typologies. This allows us to reuse the same
+# mapping across helper functions instead of redefining it in each place.
+TYPOLOGY_CLASSES = {
+    "Temporistics": TypologyTemporistics,
+    "Psychosophia": TypologyPsychosophia,
+    "Amatoric": TypologyAmatoric,
+    "Socionics": TypologySocionics,
+}
+
+
+def get_types_by_typology(typology_name):
+    """Retrieve all types for a given typology.
+    In testing environments caching is skipped."""
+    typology_class = TYPOLOGY_CLASSES.get(typology_name)
+    if not typology_class:
+        return None
+
+    if current_app.config.get("TESTING", False) or current_app.config.get(
+        "CACHE_TYPE"
+    ) == "NullCache":
+        return typology_class().get_all_types()
+    else:
+        return _get_types_cached(typology_name, typology_class)
+
+
+@cache.memoize(timeout=3600)
+def _get_types_cached(typology_name, typology_class):
+    """Cached version of get_types_by_typology."""
+    return typology_class().get_all_types()
+
+
+def calculate_relationship(user1, user2, typology):
+    if not user1 or not user2:
+        raise ValueError("User types cannot be empty")
+    typology_class = TYPOLOGY_CLASSES.get(typology)
+    if typology_class is None:
+        raise ValueError(f"Invalid typology: {typology}")
+    typology_instance = typology_class()
+    relationship_type = typology_instance.determine_relationship_type(user1, user2)
+    comfort_score, _ = typology_instance.get_comfort_score(relationship_type)
+    return relationship_type, comfort_score
+
+
+def haversine_distance(lat1, lon1, lat2, lon2):
+    R = 6371.0
+    lat1_rad, lon1_rad = math.radians(lat1), math.radians(lon1)
+    lat2_rad, lon2_rad = math.radians(lat2), math.radians(lon2)
+    dlat = lat2_rad - lat1_rad
+    dlon = lon2_rad - lon1_rad
+    a = math.sin(dlat / 2) ** 2 + math.cos(lat1_rad) * math.cos(lat2_rad) * math.sin(dlon / 2) ** 2
+    c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+    distance = R * c
+    return distance
+
+
+def get_users_distance(user1, user2):
+    if (
+        user1.latitude is None
+        or user1.longitude is None
+        or user2.latitude is None
+        or user2.longitude is None
+    ):
+        raise ValueError("Both users must have coordinates set")
+    return haversine_distance(
+        user1.latitude, user1.longitude, user2.latitude, user2.longitude
+    )
+
+
+def get_distance_if_compatible(user1, user2):
+    if user1.user_type is None or user2.user_type is None:
+        raise ValueError("Both users must have a user_type assigned")
+    relationship_type, comfort_score = calculate_relationship(
+        user1.user_type.type_value,
+        user2.user_type.type_value,
+        user1.user_type.typology_name,
+    )
+    if comfort_score <= 50:
+        raise ValueError("Users are not compatible enough to consider meeting")
+
+    distance = get_users_distance(user1, user2)
+
+    if user1.max_distance is not None and distance > user1.max_distance:
+        raise ValueError(
+            f"User is too far away (distance: {distance:.2f} km, max: {user1.max_distance:.2f} km)"
+        )
+
+    return distance
+
+
+def get_typology_instance(typology_name):
+    typology_class = TYPOLOGY_CLASSES.get(typology_name)
+    if typology_class is None:
+        return None
+    return typology_class()
+

--- a/app/domain_services.py
+++ b/app/domain_services.py
@@ -53,6 +53,7 @@ def calculate_relationship(user1, user2, typology):
 
 
 def haversine_distance(lat1, lon1, lat2, lon2):
+    """Return the distance in kilometers between two geographic coordinates."""
     R = 6371.0
     lat1_rad, lon1_rad = math.radians(lat1), math.radians(lon1)
     lat2_rad, lon2_rad = math.radians(lat2), math.radians(lon2)
@@ -65,6 +66,7 @@ def haversine_distance(lat1, lon1, lat2, lon2):
 
 
 def get_users_distance(user1, user2):
+    """Return the distance between two users based on their coordinates."""
     if (
         user1.latitude is None
         or user1.longitude is None

--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -1,0 +1,5 @@
+from .user_repository import update_user_profile
+
+__all__ = [
+    "update_user_profile",
+]

--- a/app/repositories/user_repository.py
+++ b/app/repositories/user_repository.py
@@ -1,0 +1,51 @@
+from app.extensions import db
+
+
+def update_user_profile(
+    user,
+    username,
+    email,
+    typology_name,
+    type_value,
+    latitude,
+    longitude,
+    city=None,
+    country=None,
+    profession=None,
+    profession_visible=None,
+    max_distance=None,
+):
+    """Update user profile information and commit to the database."""
+    user.username = username
+    user.email = email
+
+    if user.user_type:
+        user.user_type.typology_name = typology_name
+        user.user_type.type_value = type_value
+    else:
+        from app.models import UserType
+
+        user_type = UserType(typology_name=typology_name, type_value=type_value)
+        db.session.add(user_type)
+        db.session.commit()
+        user.type_id = user_type.id
+
+    user.latitude = latitude
+    user.longitude = longitude
+
+    if city is not None:
+        user.city = city
+    if country is not None:
+        user.country = country
+    if profession is not None:
+        user.profession = profession
+    if profession_visible is not None:
+        user.profession_visible = profession_visible
+
+    if max_distance is not None:
+        user.max_distance = max_distance
+
+    db.session.commit()
+
+    return user
+

--- a/app/routes.py
+++ b/app/routes.py
@@ -297,7 +297,7 @@ def user_profile(username):
 def edit_profile():
     form = EditProfileForm(obj=current_user)
     if form.validate_on_submit():
-        from .services import update_user_profile
+        from .repositories.user_repository import update_user_profile
         old_image_filename = current_user.profile_image
 
         # Update user profile data (no commit yet)

--- a/app/services.py
+++ b/app/services.py
@@ -1,121 +1,23 @@
-import math
-from flask import current_app
-from .extensions import db, cache
-from .typologies import (
-    TypologyTemporistics,
-    TypologyPsychosophia,
-    TypologyAmatoric,
-    TypologySocionics,
+"""Compatibility layer for service functions."""
+
+from .domain_services import (
+    get_types_by_typology,
+    calculate_relationship,
+    haversine_distance,
+    get_users_distance,
+    get_distance_if_compatible,
+    get_typology_instance,
 )
 
-# Central registry for available typologies. This allows us to reuse the same
-# mapping across helper functions instead of redefining it in each place.
-TYPOLOGY_CLASSES = {
-    "Temporistics": TypologyTemporistics,
-    "Psychosophia": TypologyPsychosophia,
-    "Amatoric": TypologyAmatoric,
-    "Socionics": TypologySocionics,
-}
+# update_user_profile is now located in app.repositories.user_repository
+from .repositories.user_repository import update_user_profile
 
-def get_types_by_typology(typology_name):
-    """Отримання всіх типів для заданої типології.
-    У тестовому середовищі не використовує кешування."""
-    typology_class = TYPOLOGY_CLASSES.get(typology_name)
-    if not typology_class:
-        return None
-    
-    # Перевіряємо, чи знаходимося в тестовому середовищі
-    if current_app.config.get('TESTING', False) or current_app.config.get('CACHE_TYPE') == 'NullCache':
-        return typology_class().get_all_types()
-    else:
-        # Використовуємо кешування лише в не-тестовому середовищі
-        return _get_types_cached(typology_name, typology_class)
-
-@cache.memoize(timeout=3600)  # Cache the result for 1 hour
-def _get_types_cached(typology_name, typology_class):
-    """Кешована версія отримання типів."""
-    return typology_class().get_all_types()
-
-def calculate_relationship(user1, user2, typology):
-    if not user1 or not user2:
-        raise ValueError("User types cannot be empty")
-    typology_class = TYPOLOGY_CLASSES.get(typology)
-    if typology_class is None:
-        raise ValueError(f"Invalid typology: {typology}")
-    typology_instance = typology_class()
-    relationship_type = typology_instance.determine_relationship_type(user1, user2)
-    comfort_score, _ = typology_instance.get_comfort_score(relationship_type)
-    return relationship_type, comfort_score
-
-def update_user_profile(user, username, email, typology_name, type_value, latitude, longitude,
-                        city=None, country=None, profession=None, profession_visible=None, max_distance=None):
-    user.username = username
-    user.email = email
-    if user.user_type:
-        user.user_type.typology_name = typology_name
-        user.user_type.type_value = type_value
-    else:
-        from app.models import UserType
-        user_type = UserType(
-            typology_name=typology_name,
-            type_value=type_value
-        )
-        db.session.add(user_type)
-        db.session.commit()
-        user.type_id = user_type.id
-
-    user.latitude = latitude
-    user.longitude = longitude
-    if city is not None:
-        user.city = city
-    if country is not None:
-        user.country = country
-    if profession is not None:
-        user.profession = profession
-    if profession_visible is not None:
-        user.profession_visible = profession_visible
-    
-    # Оновлюємо максимальну прийнятну відстань, якщо вона вказана
-    if max_distance is not None:
-        user.max_distance = max_distance
-    
-    db.session.commit()
-
-def haversine_distance(lat1, lon1, lat2, lon2):
-    R = 6371.0
-    lat1_rad, lon1_rad = math.radians(lat1), math.radians(lon1)
-    lat2_rad, lon2_rad = math.radians(lat2), math.radians(lon2)
-    dlat = lat2_rad - lat1_rad
-    dlon = lon2_rad - lon1_rad
-    a = math.sin(dlat / 2)**2 + math.cos(lat1_rad)*math.cos(lat2_rad)*math.sin(dlon / 2)**2
-    c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
-    distance = R * c
-    return distance
-
-def get_users_distance(user1, user2):
-    if user1.latitude is None or user1.longitude is None or user2.latitude is None or user2.longitude is None:
-        raise ValueError("Both users must have coordinates set")
-    return haversine_distance(user1.latitude, user1.longitude, user2.latitude, user2.longitude)
-
-def get_distance_if_compatible(user1, user2):
-    from .services import calculate_relationship
-    if user1.user_type is None or user2.user_type is None:
-        raise ValueError("Both users must have a user_type assigned")
-    relationship_type, comfort_score = calculate_relationship(user1.user_type.type_value, user2.user_type.type_value, user1.user_type.typology_name)
-    if comfort_score <= 50:
-        raise ValueError("Users are not compatible enough to consider meeting")
-    
-    # Отримуємо відстань між користувачами
-    distance = get_users_distance(user1, user2)
-    
-    # Перевіряємо, чи відстань не перевищує максимальну прийнятну відстань для першого користувача
-    if user1.max_distance is not None and distance > user1.max_distance:
-        raise ValueError(f"User is too far away (distance: {distance:.2f} km, max: {user1.max_distance:.2f} km)")
-    
-    return distance
-
-def get_typology_instance(typology_name):
-    typology_class = TYPOLOGY_CLASSES.get(typology_name)
-    if typology_class is None:
-        return None
-    return typology_class()
+__all__ = [
+    "get_types_by_typology",
+    "calculate_relationship",
+    "haversine_distance",
+    "get_users_distance",
+    "get_distance_if_compatible",
+    "get_typology_instance",
+    "update_user_profile",
+]


### PR DESCRIPTION
## Summary
- split service-layer logic into `domain_services` and `user_repository`
- keep `services` as a thin compatibility layer
- update routes to import from the repository

## Testing
- `export PYTHONPATH="$PYTHONPATH:$(pwd)"`
- `export USE_TEST_DB_URL="sqlite:///test.db"`
- `export FLASK_CONFIG=testing`
- `export TEST_DB=sqlite`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503a7420e88323b6159d2da9e623f8