### PR TITLE
Add pluggable chat provider system

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ A high test coverage (~93%) confirms that the theoretical ideas are correctly mi
    BABEL_DEFAULT_LOCALE=en
    BABEL_DEFAULT_TIMEZONE=Europe/Kiev
    LANGUAGES=en,fr,es,uk
+   # Chat configuration
+   CHAT_PROVIDER=openai               # "openai", "huggingface", "gemini", "anthropic"
+   OPENAI_MODEL=gpt-3.5-turbo
+   OPENAI_API_KEY=your-openai-key
+   HUGGINGFACE_MODEL=google/flan-t5-small
+   HUGGINGFACE_API_TOKEN=your-hf-token
+   GEMINI_MODEL=gemini-pro
+   GEMINI_API_KEY=your-gemini-key
+   ANTHROPIC_MODEL=claude-3-haiku-20240307
+   ANTHROPIC_API_KEY=your-anthropic-key
    ```
 
 3. **Run the development server**:

--- a/app/chat_providers.py
+++ b/app/chat_providers.py
@@ -1,0 +1,89 @@
+# Chat providers for the assistant
+import os
+import openai
+import requests
+import google.generativeai as genai
+import anthropic
+from flask import current_app
+
+class ChatProvider:
+    """Abstract provider for chat models."""
+    def reply(self, message: str) -> str:
+        raise NotImplementedError
+
+class OpenAIProvider(ChatProvider):
+    def __init__(self, model: str, api_key: str):
+        self.model = model
+        openai.api_key = api_key
+
+    def reply(self, message: str) -> str:
+        response = openai.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": message}],
+            temperature=0.7,
+        )
+        return response.choices[0].message.content.strip()
+
+class HuggingFaceProvider(ChatProvider):
+    def __init__(self, model: str, api_token: str | None = None):
+        self.model = model
+        self.api_url = f"https://api-inference.huggingface.co/models/{model}"
+        self.headers = {"Authorization": f"Bearer {api_token}"} if api_token else {}
+
+    def reply(self, message: str) -> str:
+        resp = requests.post(
+            self.api_url,
+            headers=self.headers,
+            json={"inputs": message},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if isinstance(data, list) and data:
+            return data[0].get("generated_text", "")
+        return data.get("generated_text", "")
+
+class GeminiProvider(ChatProvider):
+    def __init__(self, model: str, api_key: str):
+        genai.configure(api_key=api_key)
+        self.model = genai.GenerativeModel(model)
+
+    def reply(self, message: str) -> str:
+        response = self.model.generate_content(message)
+        return getattr(response, "text", str(response))
+
+class AnthropicProvider(ChatProvider):
+    def __init__(self, model: str, api_key: str):
+        self.client = anthropic.Client(api_key)
+        self.model = model
+
+    def reply(self, message: str) -> str:
+        resp = self.client.messages.create(
+            model=self.model,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": message}],
+        )
+        content = resp.content
+        if isinstance(content, list) and content:
+            part = content[0]
+            if hasattr(part, "text"):
+                return part.text
+        return str(content)
+
+def get_chat_provider() -> ChatProvider:
+    provider = current_app.config.get("CHAT_PROVIDER", "openai")
+    if provider == "huggingface":
+        model = current_app.config.get("HUGGINGFACE_MODEL", "google/flan-t5-small")
+        token = current_app.config.get("HUGGINGFACE_API_TOKEN") or os.environ.get("HUGGINGFACE_API_TOKEN")
+        return HuggingFaceProvider(model, token)
+    if provider == "gemini":
+        model = current_app.config.get("GEMINI_MODEL", "gemini-pro")
+        api_key = current_app.config.get("GEMINI_API_KEY") or os.environ.get("GEMINI_API_KEY")
+        return GeminiProvider(model, api_key)
+    if provider == "anthropic":
+        model = current_app.config.get("ANTHROPIC_MODEL", "claude-3-haiku-20240307")
+        api_key = current_app.config.get("ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_API_KEY")
+        return AnthropicProvider(model, api_key)
+    model = current_app.config.get("OPENAI_MODEL", "gpt-3.5-turbo")
+    api_key = current_app.config.get("OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    return OpenAIProvider(model, api_key)

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,15 @@
-from flask import (Blueprint, render_template, request, jsonify, current_app, redirect, url_for, flash, make_response, abort)
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    jsonify,
+    current_app,
+    redirect,
+    url_for,
+    flash,
+    make_response,
+    abort,
+)
 from flask_login import login_user, logout_user, login_required, current_user
 from .forms import RegistrationForm, LoginForm, ProfileForm, EditProfileForm
 from .models import User, UserType
@@ -18,7 +29,7 @@ from werkzeug.utils import secure_filename
 import os
 from .routes_helper import handle_profile_image_upload, update_user_typology
 from .statistics_utils import load_typology_status
-import openai
+from .chat_providers import get_chat_provider
 
 main = Blueprint("main", __name__)
 
@@ -407,18 +418,11 @@ def chat_api():
     message = data.get("message", "") if data else ""
     if not message:
         return jsonify({"reply": "No message provided."}), 400
-    api_key = current_app.config.get("OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        return jsonify({"reply": "OpenAI API key not configured."})
+
+    provider = get_chat_provider()
     try:
-        openai.api_key = api_key
-        response = openai.chat.completions.create(
-            model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": message}],
-            temperature=0.7,
-        )
-        reply = response.choices[0].message.content.strip()
+        reply = provider.reply(message)
     except Exception as e:
-        current_app.logger.error(f"OpenAI error: {e}")
+        current_app.logger.error(f"Chat provider error: {e}")
         reply = "Sorry, I cannot respond right now."
     return jsonify({"reply": reply})

--- a/config.py
+++ b/config.py
@@ -18,6 +18,15 @@ class Config:
     BABEL_DEFAULT_TIMEZONE = os.environ.get("BABEL_DEFAULT_TIMEZONE", "UTC")
     LANGUAGES = os.environ.get("LANGUAGES", "en,fr,es,uk").split(",")
     UPLOAD_FOLDER = os.path.join(basedir, 'app', 'static', 'uploads')
+    CHAT_PROVIDER = os.environ.get("CHAT_PROVIDER", "openai")
+    OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-3.5-turbo")
+    OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+    HUGGINGFACE_MODEL = os.environ.get("HUGGINGFACE_MODEL", "google/flan-t5-small")
+    HUGGINGFACE_API_TOKEN = os.environ.get("HUGGINGFACE_API_TOKEN")
+    GEMINI_MODEL = os.environ.get("GEMINI_MODEL", "gemini-pro")
+    GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY")
+    ANTHROPIC_MODEL = os.environ.get("ANTHROPIC_MODEL", "claude-3-haiku-20240307")
+    ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
 
 class DevelopmentConfig(Config):
     DEBUG = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,6 @@ webdriver-manager==4.0.1
 Pillow==10.2.0
 
 openai==1.3.2
+requests==2.31.0
+google-generativeai==0.8.5
+anthropic==0.54.0


### PR DESCRIPTION
## Summary
- implement chat provider abstraction and support OpenAI or HuggingFace
- make chat API select provider dynamically
- expose provider configuration in `config.py`
- document new environment variables in README
- require `requests` library
- add Gemini and Anthropic support

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503a016774832386d041881ed821dd