### PR TITLE
Add IQ typology

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Conflict: a synthetic individual acts holistically without dissecting details, w
 
 Conflict: Different types struggle to "mirror" or understand the other's model of perception.
 
+### IQ Typology
+- **Gentle levels:** Aspiring, Balanced, Insightful.
+- Emphasizes how cognitive approaches influence compatibility.
+
 ## Implementation in Code
 
 ### Typology Classes
@@ -106,6 +110,7 @@ Under `app/typologies/`, each typology is implemented as a class derived from an
 - `get_comfort_score()` to determine a "comfort score" based on their relationship.
 
 These methods directly reflect the theoretical principles: induction/deduction (Temporistics), analysis/synthesis (Psychosophy), and modeling (Socionics).
+The same interface now exposes an additional `TypologyIQ` class for comparing gentle IQ levels.
 
 ### Services and Data Validation
 `services.py` contains:

--- a/app/relationship_calculator.py
+++ b/app/relationship_calculator.py
@@ -5,6 +5,7 @@ from .typologies.typology_temporistics import TypologyTemporistics
 from .typologies.typology_psychosophia import TypologyPsychosophia
 from .typologies.typology_amatoric import TypologyAmatoric
 from .typologies.typology_socionics import TypologySocionics
+from .typologies.typology_iq import TypologyIQ
 
 
 # Function to load relationship data from a JSON file
@@ -223,6 +224,7 @@ def main():
         "Psychosophia": TypologyPsychosophia(),
         "Amatoric": TypologyAmatoric(),
         "Socionics": TypologySocionics(),
+        "IQ": TypologyIQ(),
     }
     print("Available typologies:")
     for idx, typology_name in enumerate(available_typologies.keys(), start=1):

--- a/app/services.py
+++ b/app/services.py
@@ -6,6 +6,7 @@ from .typologies import (
     TypologyPsychosophia,
     TypologyAmatoric,
     TypologySocionics,
+    TypologyIQ,
 )
 
 # Central registry for available typologies. This allows us to reuse the same
@@ -15,6 +16,7 @@ TYPOLOGY_CLASSES = {
     "Psychosophia": TypologyPsychosophia,
     "Amatoric": TypologyAmatoric,
     "Socionics": TypologySocionics,
+    "IQ": TypologyIQ,
 }
 
 def get_types_by_typology(typology_name):

--- a/app/statistics_utils.py
+++ b/app/statistics_utils.py
@@ -23,6 +23,7 @@ def load_typology_weights() -> Dict[str, float]:
             "Psychosophia": 1.0,
             "Amatoric": 1.0,
             "Socionics": 1.0,
+            "IQ": 1.0,
         }
         with open(WEIGHTS_FILE, "w") as f:
             json.dump(weights, f, indent=2)
@@ -45,6 +46,7 @@ def load_typology_status() -> Dict[str, bool]:
             "Psychosophia": True,
             "Amatoric": True,
             "Socionics": True,
+            "IQ": True,
         }
         with open(STATUS_FILE, "w") as f:
             json.dump(status, f, indent=2)

--- a/app/typologies/__init__.py
+++ b/app/typologies/__init__.py
@@ -9,6 +9,7 @@ from .typology_temporistics import TypologyTemporistics
 from .typology_psychosophia import TypologyPsychosophia
 from .typology_amatoric import TypologyAmatoric
 from .typology_socionics import TypologySocionics
+from .typology_iq import TypologyIQ
 
 # List all the classes that should be available when importing the package
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     "TypologyPsychosophia",
     "TypologyAmatoric",
     "TypologySocionics",
+    "TypologyIQ",
 ]
 
 # This allows the classes to be imported directly from the package

--- a/app/typologies/typology_iq.py
+++ b/app/typologies/typology_iq.py
@@ -1,0 +1,32 @@
+from .typology import Typology
+
+
+class TypologyIQ(Typology):
+    """Gentle IQ gradation: Aspiring, Balanced, and Insightful."""
+
+    def __init__(self):
+        super().__init__(["Aspiring", "Balanced", "Insightful"])
+
+    def get_all_types(self):
+        return self.aspects
+
+    def shorten_type(self, types):
+        if isinstance(types, str):
+            types = [types]
+        return [t[0] for t in types]
+
+    def determine_relationship_type(self, user1_type: str, user2_type: str) -> str:
+        if user1_type == user2_type:
+            return "Identity"
+        idx1 = self.aspects.index(user1_type)
+        idx2 = self.aspects.index(user2_type)
+        if abs(idx1 - idx2) == 1:
+            return "Complementary"
+        return "Contrast"
+
+    def get_comfort_score(self, relationship_type: str) -> (int, str):
+        if relationship_type == "Identity":
+            return 80, "Similar cognitive style"
+        if relationship_type == "Complementary":
+            return 60, "Balanced perspectives"
+        return 40, "Distinct approaches"

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -38,6 +38,12 @@ def test_get_types_psychosophia(app, test_db):
         assert types is not None
         assert len(types) > 0
 
+def test_get_types_iq(app, test_db):
+    with app.app_context():
+        types = get_types_by_typology("IQ")
+        assert types is not None
+        assert len(types) == 3
+
 def test_calculate_relationship_invalid_typology(app, test_db):
     with app.app_context():
         with pytest.raises(ValueError):

--- a/tests/test_temporistics_test.py
+++ b/tests/test_temporistics_test.py
@@ -14,3 +14,10 @@ def test_calculate_temporistics_type_future_priority():
     answers = ["C", "C", "B", "A"]
     result = calculate_temporistics_type(answers)
     assert result.startswith("Future")
+
+
+def test_calculate_temporistics_type_invalid_answer():
+    """Invalid options should raise ValueError."""
+    answers = ["A", "X", "C", "D"]
+    with pytest.raises(ValueError):
+        calculate_temporistics_type(answers)

--- a/tests/test_typologies.py
+++ b/tests/test_typologies.py
@@ -192,3 +192,16 @@ def test_temporistics_get_time_periods_short():
     """Check that temporal aspects are shortened to initials."""
     short = TypologyTemporistics.get_time_periods_short(["Past", "Current", "Future", "Eternity"])
     assert short == ["P", "C", "F", "E"]
+
+
+def test_typology_iq_basic():
+    from app.typologies.typology_iq import TypologyIQ
+
+    typ = TypologyIQ()
+    all_types = typ.get_all_types()
+    assert all_types == ["Aspiring", "Balanced", "Insightful"]
+    assert typ.determine_relationship_type("Aspiring", "Aspiring") == "Identity"
+    assert typ.determine_relationship_type("Aspiring", "Balanced") == "Complementary"
+    assert typ.determine_relationship_type("Aspiring", "Insightful") == "Contrast"
+    shortened = typ.shorten_type(all_types)
+    assert shortened == ["A", "B", "I"]


### PR DESCRIPTION
## Summary
- introduce simple TypologyIQ class
- register IQ typology in app services and calculators
- extend statistics defaults for IQ support
- cover TypologyIQ in tests
- refine IQ typology gradation

## Testing
- `PYTHONPATH=. pytest -q tests/test_typologies.py::test_typology_iq_basic -q`
- `PYTHONPATH=. pytest -q` *(fails: psycopg2 SystemError)*

------
https://chatgpt.com/codex/tasks/task_e_6850374312208323b7852be0c96159e4