### PR TITLE
Use SQLite for testing

### DIFF
--- a/run_local.sh
+++ b/run_local.sh
@@ -61,8 +61,8 @@ run_tests() {
     # Configure the testing environment
     export PYTHONPATH="$PYTHONPATH:$(pwd)"
     
-    # Use PostgreSQL for tests
-    export USE_TEST_DB_URL="postgresql://testuser:password@localhost:5432/testdb"
+    # Use SQLite for tests unless USE_TEST_DB_URL is already set
+    export USE_TEST_DB_URL="${USE_TEST_DB_URL:-sqlite:///test.db}"
     
     export FLASK_CONFIG=testing
     

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def db_url():
     if env_url:
         return env_url
 
-    db_type = os.environ.get("TEST_DB", "postgresql").lower()
+    db_type = os.environ.get("TEST_DB", "sqlite").lower()
     if db_type == "sqlite":
         return "sqlite:///:memory:"
 


### PR DESCRIPTION
## Summary
- default to SQLite in tests
- allow SQLite default in run_local script

## Testing
- `python -m pytest -k 'not selenium' -vv` *(fails: ImportError ...)*

------
https://chatgpt.com/codex/tasks/task_e_68503f69a80883239319ecd9f28436f5