### PR TITLE
Add comfort score tuning CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ new random values for the variables above and updates your `.env` file.
 Add a monthly cron job, e.g. `0 0 1 * * /usr/bin/python /path/to/rotate_secrets.py`,
 to rotate secrets regularly.
 
+To fine‑tune compatibility values during research, use `adjust_comfort_score.py`:
+
+```bash
+python adjust_comfort_score.py Psychosophia "Identity/Philia" 75 --data-dir data
+```
+
+This updates the corresponding JSON file with the provided score.
+
 3. **Run the development server**:
 
    Recommended approach using `run_local.sh`:

--- a/adjust_comfort_score.py
+++ b/adjust_comfort_score.py
@@ -1,0 +1,28 @@
+import argparse
+import os
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Update comfort score for a relationship type")
+    parser.add_argument("typology", help="Typology name, e.g. Temporistics")
+    parser.add_argument("relationship", help="Relationship type to modify")
+    parser.add_argument("score", type=int, help="New comfort score")
+    parser.add_argument(
+        "--data-dir", help="Custom data directory containing *_comfort_scores.json", default=None
+    )
+    args = parser.parse_args()
+
+    if args.data_dir:
+        os.environ["DATA_DIR"] = args.data_dir
+
+    # Import after setting DATA_DIR so statistics_utils picks up the path
+    from app.statistics_utils import update_comfort_score
+
+    update_comfort_score(args.typology, args.relationship, args.score)
+    print(
+        f"Updated {args.typology} relationship '{args.relationship}' to score {args.score}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_adjust_comfort_score_script.py
+++ b/tests/test_adjust_comfort_score_script.py
@@ -1,0 +1,22 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from app import statistics_utils as su
+
+
+def test_adjust_comfort_score_script(tmp_path, monkeypatch):
+    src = su.get_data_path("psychosophia_comfort_scores.json")
+    dest = tmp_path / "psychosophia_comfort_scores.json"
+    shutil.copy(src, dest)
+
+    script = Path("adjust_comfort_score.py")
+    result = subprocess.run(
+        ["python", str(script), "Psychosophia", "Identity/Philia", "77", "--data-dir", str(tmp_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    with open(dest) as f:
+        data = json.load(f)
+    assert data["Identity/Philia"]["score"] == 77


### PR DESCRIPTION
## Summary
- add `adjust_comfort_score.py` helper script for updating comfort scores
- document the new script in README
- test the script via `test_adjust_comfort_score_script.py`

## Testing
- `python -m pytest tests/test_adjust_comfort_score_script.py -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505c228b0c8323aeac84dd408644c5