### PR TITLE
Add architecture documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,56 @@
+# Architecture Overview
+
+This document explains how the components of the Psychological Calculator project interact and the flow of data through the system.
+
+## High-Level Components
+
+- **Flask Application Factory** (`app/__init__.py`) sets up extensions, registers blueprints and configures OAuth providers.
+- **Routes / Views** (`app/routes.py` and `app/admin/`) handle user requests, render templates and invoke services.
+- **Services** (`app/services.py`) encapsulate business logic such as typology calculations and user utilities.
+- **Typology Modules** (`app/typologies/`) implement the rules for each typology (Temporistics, Psychosophy, etc.).
+- **Database Models** (`app/models.py`) persist user accounts, type selections and OAuth tokens using SQLAlchemy.
+- **Templates** (`app/templates/`) generate the HTML pages shown in the browser.
+
+### Component Interaction
+
+```mermaid
+flowchart TD
+    Browser -->|HTTP requests| FlaskApp
+    FlaskApp -->|blueprints| Routes
+    Routes --> Services
+    Services --> Typologies
+    Services --> Database
+    Database --> Services
+    Services --> Routes
+    Routes -->|HTML response| Browser
+```
+
+## Data Flow
+
+1. **User request**: a browser sends an HTTP request to the Flask application (e.g. submitting two types for comparison).
+2. **Routing**: the request is routed to the appropriate view function within a blueprint.
+3. **Service layer**: views call helper functions in `services.py` to retrieve available types, compute compatibility and interact with the database.
+4. **Typology logic**: services invoke classes in `app/typologies/` to calculate relationship types and comfort scores.
+5. **Database access**: results may be stored via SQLAlchemy models in `app/models.py`.
+6. **Response**: a template is rendered with the calculated data and returned to the browser.
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant W as Web Server
+    participant S as Service Layer
+    participant T as Typology Module
+    participant D as Database
+
+    U->>W: Submit types via form
+    W->>S: Call `calculate_relationship`
+    S->>T: Determine relation
+    S-->>D: Optional read/write
+    T-->>S: Relationship & score
+    S-->>W: Result data
+    W-->>U: Rendered template
+```
+
+These diagrams provide a starting point for understanding how the application processes requests and how data flows between components. Future microservice extraction (see `NOTE.md`) can extend this model by replacing the typology modules with API calls to dedicated services.

--- a/README.md
+++ b/README.md
@@ -6,20 +6,21 @@
    - [Key Components](#key-components)
    - [Getting Started](#getting-started)
    - [Next Steps for Exploration](#next-steps-for-exploration)
-3. [Theoretical Foundations](#theoretical-foundations)
+3. [Architecture Overview](#architecture-overview)
+4. [Theoretical Foundations](#theoretical-foundations)
     - [Temporistics (Time)](#temporistics-time)
     - [Psychosophy (Personality Aspects)](#psychosophy-personality-aspects)
     - [Socionics (Modeling of Information)](#socionics-modeling-of-information)
-4. [Implementation in Code](#implementation-in-code)
+5. [Implementation in Code](#implementation-in-code)
     - [Typology Classes](#typology-classes)
     - [Services and Data Validation](#services-and-data-validation)
     - [Routes and Forms](#routes-and-forms)
-5. [Testing](#testing)
-6. [Installation and Run](#installation-and-run)
+6. [Testing](#testing)
+7. [Installation and Run](#installation-and-run)
     - [Local Run](#local-run)
     - [Running with Docker](#running-with-docker)
     - [Running Tests](#running-tests)
-7. [Additional Information](#additional-information)
+8. [Additional Information](#additional-information)
 
 ---
 
@@ -68,6 +69,12 @@ Recent updates introduce accessibility and responsive design best practices:
 - Look into OAuth configuration in `app/oauth.py`.
 - Explore the test suite under `tests/` for usage examples.
 - Check `translations/` to see how localization is added.
+
+## Architecture Overview
+
+The project follows a standard Flask blueprint structure with a dedicated service layer and typology modules.
+For a detailed description and diagrams of how requests move through these components, see
+[ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## Theoretical Foundations
 


### PR DESCRIPTION
## Summary
- add `ARCHITECTURE.md` with diagrams of components and data flow
- link to the new document from `README`
- update table of contents accordingly

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685061e3ba6c8323a97431c6392f36db