### PR TITLE
Add basic REST API

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -58,8 +58,10 @@ def create_app(config_name="development"):
     # Регіструємо blueprint'и
     from app.routes import main
     from app.admin import admin_bp
+    from app.api import api_bp
     app.register_blueprint(main)
     app.register_blueprint(admin_bp)
+    app.register_blueprint(api_bp)
     
     # Ініціалізуємо OAuth, окрім тестового оточення. У тестах залежність
     # flask-dance може бути відсутня, тому пропускаємо реєстрацію OAuth

--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,31 @@
+from flask import Blueprint, request, jsonify
+from .services import get_types_by_typology, calculate_relationship
+
+api_bp = Blueprint('api', __name__, url_prefix='/api')
+
+@api_bp.route('/types', methods=['GET'])
+def get_types_api():
+    typology = request.args.get('typology')
+    if not typology:
+        return jsonify({'error': 'Missing typology parameter'}), 400
+    types = get_types_by_typology(typology)
+    if types is None:
+        return jsonify({'error': f'Unknown typology: {typology}'}), 400
+    return jsonify({'types': types})
+
+@api_bp.route('/calculate', methods=['POST'])
+def calculate_api():
+    data = request.get_json() or {}
+    user1 = data.get('user1')
+    user2 = data.get('user2')
+    typology = data.get('typology')
+
+    if not user1 or not user2 or not typology:
+        return jsonify({'error': 'Missing parameters'}), 400
+
+    try:
+        relationship, score = calculate_relationship(user1, user2, typology)
+    except ValueError as exc:
+        return jsonify({'error': str(exc)}), 400
+
+    return jsonify({'relationship_type': relationship, 'comfort_score': score})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,31 @@
+import pytest
+
+
+def test_api_get_types(client, app, test_db):
+    with app.app_context():
+        response = client.get('/api/types?typology=Temporistics')
+        assert response.status_code == 200
+        data = response.get_json()
+        assert 'types' in data
+        assert any('Past' in t for t in data['types'])
+
+
+def test_api_calculate(client, app, test_db):
+    with app.app_context():
+        payload = {
+            'user1': 'Past, Current, Future, Eternity',
+            'user2': 'Past, Current, Future, Eternity',
+            'typology': 'Temporistics'
+        }
+        response = client.post('/api/calculate', json=payload)
+        assert response.status_code == 200
+        data = response.get_json()
+        assert 'relationship_type' in data
+        assert 'comfort_score' in data
+
+
+def test_api_calculate_missing_params(client, app, test_db):
+    with app.app_context():
+        response = client.post('/api/calculate', json={'user1': 'A'})
+        assert response.status_code == 400
+


### PR DESCRIPTION
## Summary
- expose new `/api` blueprint with routes for compatibility calculations
- register the API blueprint during app creation
- ensure calculations and type lookups are accessible via JSON
- test the new API endpoints

## Testing
- `pytest -k "not selenium"`

------
https://chatgpt.com/codex/tasks/task_e_685061a9e58c83239942f0eecec811f5