### PR TITLE
Expose gettext in templates

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,6 +8,7 @@ from flask_babel import Babel, _
 from flask_caching import Cache
 from flask_wtf.csrf import CSRFProtect
 from flask_talisman import Talisman
+from app.context_processors import inject_translation
 
 # Змінні оточення вже завантажує Dynaconf у config.py
 cache = Cache()
@@ -47,6 +48,7 @@ def create_app(config_name="development"):
     
     cache.init_app(app)
     babel.init_app(app)
+    app.context_processor(inject_translation)
     login_manager.init_app(app)
     csrf.init_app(app)
     talisman.init_app(


### PR DESCRIPTION
## Summary
- register translation context processor
- expose `gettext` and `current_locale` to templates

## Testing
- `PYTHONPATH=. pytest -q tests/test_localization.py::test_available_translations -q`

------
https://chatgpt.com/codex/tasks/task_e_68511e8e13f08323a20b1ebf070b13c9