### PR TITLE
Integrate Flask-User for password hashing

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,6 +9,7 @@ from flask_caching import Cache
 from flask_wtf.csrf import CSRFProtect
 from flask_talisman import Talisman
 from app.context_processors import inject_translation
+from flask_user import SQLAlchemyAdapter, UserManager
 
 # Змінні оточення вже завантажує Dynaconf у config.py
 cache = Cache()
@@ -56,6 +57,10 @@ def create_app(config_name="development"):
         content_security_policy=app.config.get("CONTENT_SECURITY_POLICY"),
         force_https=app.config.get("TALISMAN_FORCE_HTTPS", False),
     )
+
+    # Set up Flask-User
+    from app.models import User
+    user_manager = UserManager(SQLAlchemyAdapter(db, User), app)
     
     # Регіструємо blueprint'и
     from app.routes import main

--- a/app/routes.py
+++ b/app/routes.py
@@ -217,7 +217,7 @@ def login():
     github_enabled = 'github' in current_app.blueprints
     if form.validate_on_submit():
         user = User.query.filter_by(email=form.email.data).first()
-        if user and user.check_password(form.password.data):
+        if user and current_app.user_manager.verify_password(form.password.data, user.password_hash):
             login_user(user, remember=form.remember.data)
             next_page = request.args.get("next")
             if not is_safe_url(next_page):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ Flask-WTF>=1.1.1
 gunicorn==20.0.4
 python-dotenv==1.0.1
 Flask-Login==0.6.3
+Flask-User==1.0.2.2
 email-validator==1.1.1
 psycopg2-binary==2.9
 psycopg2==2.9


### PR DESCRIPTION
## Summary
- add Flask-User dependency
- initialize Flask-User in the app factory
- use library hashing for user passwords
- update login logic to verify using Flask-User

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68512315100c8323ae66fe074d7f2f01